### PR TITLE
Log JSON post requests and invalid requests

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,0 +1,15 @@
+
+
+master
+======
+
+Features:
+
+    * Log listen address, syslog address, and syslog priority to stderr
+      on startup.
+
+
+0.0.1 (2015-03-24)
+==================
+
+Initial release.

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -10,6 +10,8 @@ Features:
     * Track JSON POST requests
       (such as `curl -d '{"a": "b", "foo": "c"}' http://localhost:8080/`)
       in addition to pixel GET requests.
+    * Track invalid requests, including an error message relating why
+      the request was invalid.
 
 
 0.0.1 (2015-03-24)

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -7,6 +7,9 @@ Features:
 
     * Log listen address, syslog address, and syslog priority to stderr
       on startup.
+    * Track JSON POST requests
+      (such as `curl -d '{"a": "b", "foo": "c"}' http://localhost:8080/`)
+      in addition to pixel GET requests.
 
 
 0.0.1 (2015-03-24)

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ To install for development, just do:
 A directory to simplify debian packaging is forthcoming.
 
 
-## Usage
+## Usage & sample requests
 
 pixel is configured from the environment. A typical invocation might
 be:
@@ -24,7 +24,18 @@ be:
     LISTEN_ADDRESS=:8080 pixel
 
 
-## Quickstart (with nginx)
+pixel serves tracks both pixel GET:
+
+    curl http://localhost:8080/trk/v1.gif?a=b&foo=c
+
+and JSON POST:
+
+    curl -d '{"a": "b", "foo": "c"}' http://localhost:8080/trk/v1
+
+HTTP requests for any path.
+
+
+## Quickstart (configured with nginx)
 
 Configure pixel to run using the supervisor / container of your choice
 (runit, upstart, daemontools, docker, etc.)

--- a/README.md
+++ b/README.md
@@ -104,6 +104,17 @@ regularly to S3. (Of course, you could also easily forward your logs
 from your local syslog-ng upstream using some TCP/TLS transport.)
 
 
+## Development
+
+`go test ./...` will run all tests.
+
+`LISTEN_ADDRESS=:8080 SYSLOG_ADDRESS=127.0.0.1:5140 pixel` will run
+pixel and have it send UDP packets to 127.0.0.01:5140.
+
+`LISTEN_ADDRESS=127.0.0.1:5140 syslog-receive` (included in this repo)
+will listen on the same syslog IP:port and print UDP packets as they
+come in.
+
 ## A word on log/syslog
 
 Go's `log/syslog` sends messages to syslog in

--- a/cmd/pixel/main.go
+++ b/cmd/pixel/main.go
@@ -11,8 +11,7 @@ import (
 )
 
 func usage() {
-	fmt.Fprintf(os.Stderr,
-		"Usage: %s\n", os.Args[0])
+	fmt.Fprintf(os.Stderr, "Usage: %s\n", os.Args[0])
 	fmt.Fprintf(os.Stderr,
 		"Serves analytics HTTP requests; logs to syslog by UDP.\n"+
 			"Relevant environment variables (and defaults):\n"+
@@ -36,15 +35,13 @@ func start() error {
 		syslogAddress = "localhost:514"
 	}
 
-	syslogPriority := pixel.NewSyslogPriority(os.Getenv("SYSLOG_LEVEL"),
-		os.Getenv("SYSLOG_FACILITY"))
+	syslogPriority := pixel.NewSyslogPriority(os.Getenv("SYSLOG_LEVEL"), os.Getenv("SYSLOG_FACILITY"))
 
 	server, err := pixel.NewServer(syslogAddress, syslogPriority)
 	if err != nil {
 		return err
 	}
-	log.Printf("start listen=%s syslog=%s priority=%d\n",
-		listenAddress, syslogAddress, syslogPriority)
+	log.Printf("start listen=%s syslog=%s priority=%d\n", listenAddress, syslogAddress, syslogPriority)
 	go server.ListenAndServe(listenAddress)
 
 	sigChannel := make(chan os.Signal)

--- a/cmd/syslog-receive/main.go
+++ b/cmd/syslog-receive/main.go
@@ -3,16 +3,14 @@ package main
 import (
 	"flag"
 	"fmt"
+	"github.com/hblanks/pixel"
 	"log"
 	"net"
 	"os"
 )
 
-const UDP_MAX_BYTES = 65507
-
 func usage() {
-	fmt.Fprintf(os.Stderr,
-		"Usage: %s\n", os.Args[0])
+	fmt.Fprintf(os.Stderr, "Usage: %s\n", os.Args[0])
 	fmt.Fprintf(os.Stderr,
 		"Binds to a UDP port and prints syslog messages to stdout.\n"+
 			"Relevant environment variables (and defaults):\n"+
@@ -23,7 +21,7 @@ func usage() {
 }
 
 func syslogReceive() error {
-	messageBuf := make([]byte, UDP_MAX_BYTES)
+	messageBuf := make([]byte, pixel.UDPMaxBytes)
 
 	listenAddress := os.Getenv("LISTEN_ADDRESS")
 	if len(listenAddress) == 0 {
@@ -42,8 +40,7 @@ func syslogReceive() error {
 	defer conn.Close()
 
 	for {
-		var numBytes int
-		numBytes, _, err = conn.ReadFromUDP(messageBuf)
+		numBytes, _, err := conn.ReadFromUDP(messageBuf)
 		if err != nil {
 			log.Printf("v\n", err)
 		}

--- a/server.go
+++ b/server.go
@@ -39,9 +39,9 @@ type Event struct {
 
 const ISO8601Format = "2006-01-02T15:04:05Z"
 
-const Transparent1PxGIF = "\x47\x49\x46\x38\x39\x61\x01\x00" +
+var Transparent1PxGIF = []byte("\x47\x49\x46\x38\x39\x61\x01\x00" +
 	"\x01\x00\x80\x00\x00\xff\xff\xff\x00\x00\x00\x2c\x00\x00\x00\x00" +
-	"\x01\x00\x01\x00\x00\x02\x02\x44\x01\x00\x3b"
+	"\x01\x00\x01\x00\x00\x02\x02\x44\x01\x00\x3b")
 
 const UDPMaxBytes = 65507
 
@@ -219,7 +219,7 @@ func (s *Server) trackPixel(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.Header().Set("Content-Type", "image/gif")
-	w.Write([]byte(Transparent1PxGIF))
+	w.Write(Transparent1PxGIF)
 }
 
 func (s *Server) trackJSON(w http.ResponseWriter, r *http.Request) {

--- a/server.go
+++ b/server.go
@@ -2,6 +2,8 @@ package pixel
 
 import (
 	"encoding/json"
+	"fmt"
+	"io"
 	"log"
 	"log/syslog"
 	"net/http"
@@ -17,12 +19,18 @@ type Server struct {
 	now            func() time.Time
 }
 
+// Every pixel GET or JSON POST is an event.
 type Event struct {
-	Time      string            `json:"t"`
-	Params    map[string]string `json:"params"`
-	UserAgent string            `json:"ua,omitempty"`
-	IP        string            `json:"ip,omitempty"`
-	Proto     string            `json:"proto,omitempty"`
+	Time string `json:"t"`
+
+	// Params are client-supplied event attributes.
+	// Pixel events have params of form map[string]string.
+	// JSON POST events have arbitrary JSON.
+	Params interface{} `json:"params"`
+
+	UserAgent string `json:"ua,omitempty"`
+	IP        string `json:"ip,omitempty"`
+	Proto     string `json:"proto,omitempty"`
 }
 
 const ISO8601_FORMAT = "2006-01-02T15:04:05Z"
@@ -33,6 +41,8 @@ const TRANSPARENT_1_PX_GIF = "\x47\x49\x46\x38\x39\x61\x01\x00" +
 
 var BAD_REQUEST string
 var TRANSPARENT_1_PX_GIF_BYTES []byte
+
+const POST_BODY_MAX_LEN = 2048
 
 func init() {
 	TRANSPARENT_1_PX_GIF_BYTES = []byte(TRANSPARENT_1_PX_GIF)
@@ -127,44 +137,96 @@ func NewServer(syslogAddress string, syslogPriority syslog.Priority) (*Server, e
 	return s, err
 }
 
-func NewEvent(t time.Time, r *http.Request) (event *Event, err error) {
-	err = r.ParseForm()
-	if err != nil {
-		log.Printf("Malformed query string: %s", err)
-		return nil, err
+// Returns true if an interface is a flat mapping of strings to strings
+// or numbers.
+func isFlatJSON(i interface{}) bool {
+	m, ok := i.(map[string]interface{})
+	if !ok {
+		return false
 	}
-
-	event = &Event{
-		Time:   t.UTC().Format(ISO8601_FORMAT),
-		Params: make(map[string]string),
+	for _, v := range m {
+		switch v.(type) {
+		case string:
+		case int:
+		case float64:
+			continue
+		default:
+			return false
+		}
 	}
-
-	for key, values := range r.Form {
-		event.Params[key] = values[0]
-	}
-
-	event.UserAgent = r.Header.Get("User-Agent")
-	event.IP = r.Header.Get("X-Forwarded-For")
-	event.Proto = r.Header.Get("X-Forwarded-Proto")
-	return event, err
+	return true
 }
 
-func (s *Server) trackPixel(w http.ResponseWriter, r *http.Request) {
-	var event *Event
-	var err error
-	var jsondata []byte
+// Returns a new *Event. *http.Request can be either a pixel or a
+// JSON POST request.
+func NewEvent(t time.Time, r *http.Request) (event *Event, err error) {
+	event = &Event{
+		Time:      t.UTC().Format(ISO8601_FORMAT),
+		UserAgent: r.Header.Get("User-Agent"),
+		IP:        r.Header.Get("X-Forwarded-For"),
+		Proto:     r.Header.Get("X-Forwarded-Proto"),
+	}
 
+	switch r.Method {
+	case "GET":
+		err = r.ParseForm()
+		if err != nil {
+			err = fmt.Errorf("Malformed query string: %s", err)
+			break
+		}
+
+		params := make(map[string]string)
+		for key, values := range r.Form {
+			params[key] = values[0]
+		}
+		event.Params = params
+
+	case "POST":
+		var body []byte
+		var n int
+		if r.ContentLength > 0 {
+			if r.ContentLength > POST_BODY_MAX_LEN {
+				err = fmt.Errorf("POST body exceeds max length: %d",
+					r.ContentLength)
+				break
+			}
+			body = make([]byte, r.ContentLength)
+		} else if r.ContentLength == -1 {
+			body = make([]byte, POST_BODY_MAX_LEN)
+		} else {
+			err = fmt.Errorf("Empty POST body")
+			break
+		}
+
+		n, err = r.Body.Read(body)
+		if err != nil && err != io.EOF {
+			break
+		}
+
+		var params interface{}
+		event.Params = &params
+		err = json.Unmarshal(body[:n], event.Params)
+		if err != nil {
+			break
+		}
+
+	default:
+		err = fmt.Errorf("Invalid method %s", r.Method)
+	}
+	return
+}
+
+func (s *Server) parseRequest(w http.ResponseWriter, r *http.Request) (event *Event, err error) {
 	event, err = NewEvent(s.now(), r)
 	if err != nil {
 		log.Printf("%s", err)
 		http.Error(w, BAD_REQUEST, http.StatusBadRequest)
-		return
 	}
+	return event, err
+}
 
-	w.Header().Set("Content-Type", "image/gif")
-	w.Write(TRANSPARENT_1_PX_GIF_BYTES)
-
-	jsondata, err = json.Marshal(event)
+func (s *Server) logEvent(event *Event) {
+	jsondata, err := json.Marshal(event)
 	if err != nil {
 		log.Printf("json encode error: %s", err)
 	} else {
@@ -172,11 +234,34 @@ func (s *Server) trackPixel(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+func (s *Server) trackPixel(w http.ResponseWriter, r *http.Request) {
+	event, err := s.parseRequest(w, r)
+	if err != nil {
+		return
+	}
+	w.Header().Set("Content-Type", "image/gif")
+	w.Write(TRANSPARENT_1_PX_GIF_BYTES)
+	s.logEvent(event)
+}
+
+func (s *Server) trackJSON(w http.ResponseWriter, r *http.Request) {
+	event, err := s.parseRequest(w, r)
+	if err != nil {
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.Write([]byte("{}"))
+	s.logEvent(event)
+}
+
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
 	case "GET":
 		s.trackPixel(w, r)
 		return
+
+	case "POST":
+		s.trackJSON(w, r)
 
 	default:
 		http.Error(w, BAD_REQUEST, http.StatusBadRequest)

--- a/server.go
+++ b/server.go
@@ -37,101 +37,71 @@ type Event struct {
 	Error string `json:"error,omitempty"`
 }
 
-const ISO8601_FORMAT = "2006-01-02T15:04:05Z"
+const ISO8601Format = "2006-01-02T15:04:05Z"
 
-const TRANSPARENT_1_PX_GIF = "\x47\x49\x46\x38\x39\x61\x01\x00" +
+const Transparent1PxGIF = "\x47\x49\x46\x38\x39\x61\x01\x00" +
 	"\x01\x00\x80\x00\x00\xff\xff\xff\x00\x00\x00\x2c\x00\x00\x00\x00" +
 	"\x01\x00\x01\x00\x00\x02\x02\x44\x01\x00\x3b"
 
-var BAD_REQUEST string
-var TRANSPARENT_1_PX_GIF_BYTES []byte
+const UDPMaxBytes = 65507
 
-const POST_BODY_MAX_LEN = 2048
+var BadRequest = http.StatusText(http.StatusBadRequest)
 
-func init() {
-	TRANSPARENT_1_PX_GIF_BYTES = []byte(TRANSPARENT_1_PX_GIF)
-	BAD_REQUEST = http.StatusText(http.StatusBadRequest)
+const PostBodyMaxLen = 2048
+
+var levelMap = map[string]syslog.Priority{
+	"LOG_EMERG":   syslog.LOG_EMERG,
+	"LOG_ALERT":   syslog.LOG_ALERT,
+	"LOG_CRIT":    syslog.LOG_CRIT,
+	"LOG_ERR":     syslog.LOG_ERR,
+	"LOG_WARNING": syslog.LOG_WARNING,
+	"LOG_NOTICE":  syslog.LOG_NOTICE,
+	"LOG_INFO":    syslog.LOG_INFO,
+	"LOG_DEBUG":   syslog.LOG_DEBUG,
 }
 
-func NewSyslogPriority(level string, facility string) (p syslog.Priority) {
-	switch level {
-	case "LOG_EMERG":
-		p = syslog.LOG_EMERG
-	case "LOG_ALERT":
-		p = syslog.LOG_ALERT
-	case "LOG_CRIT":
-		p = syslog.LOG_CRIT
-	case "LOG_ERR":
-		p = syslog.LOG_ERR
-	case "LOG_WARNING":
-		p = syslog.LOG_WARNING
-	case "LOG_NOTICE":
-		p = syslog.LOG_NOTICE
-	case "LOG_INFO":
-		p = syslog.LOG_INFO
-	case "LOG_DEBUG":
-		p = syslog.LOG_DEBUG
-	default:
+var facilityMap = map[string]syslog.Priority{
+	"LOG_KERN":     syslog.LOG_KERN,
+	"LOG_USER":     syslog.LOG_USER,
+	"LOG_MAIL":     syslog.LOG_MAIL,
+	"LOG_DAEMON":   syslog.LOG_DAEMON,
+	"LOG_AUTH":     syslog.LOG_AUTH,
+	"LOG_SYSLOG":   syslog.LOG_SYSLOG,
+	"LOG_LPR":      syslog.LOG_LPR,
+	"LOG_NEWS":     syslog.LOG_NEWS,
+	"LOG_UUCP":     syslog.LOG_UUCP,
+	"LOG_CRON":     syslog.LOG_CRON,
+	"LOG_AUTHPRIV": syslog.LOG_AUTHPRIV,
+	"LOG_FTP":      syslog.LOG_FTP,
+	"LOG_LOCAL0":   syslog.LOG_LOCAL0,
+	"LOG_LOCAL1":   syslog.LOG_LOCAL1,
+	"LOG_LOCAL2":   syslog.LOG_LOCAL2,
+	"LOG_LOCAL3":   syslog.LOG_LOCAL3,
+	"LOG_LOCAL4":   syslog.LOG_LOCAL4,
+	"LOG_LOCAL5":   syslog.LOG_LOCAL5,
+	"LOG_LOCAL6":   syslog.LOG_LOCAL6,
+}
+
+func NewSyslogPriority(level string, facility string) syslog.Priority {
+	p, ok := levelMap[level]
+	if !ok {
 		p = syslog.LOG_INFO
 	}
 
-	switch facility {
-	case "LOG_KERN":
-		p |= syslog.LOG_KERN
-	case "LOG_USER":
-		p |= syslog.LOG_USER
-	case "LOG_MAIL":
-		p |= syslog.LOG_MAIL
-	case "LOG_DAEMON":
-		p |= syslog.LOG_DAEMON
-	case "LOG_AUTH":
-		p |= syslog.LOG_AUTH
-	case "LOG_SYSLOG":
-		p |= syslog.LOG_SYSLOG
-	case "LOG_LPR":
-		p |= syslog.LOG_LPR
-	case "LOG_NEWS":
-		p |= syslog.LOG_NEWS
-	case "LOG_UUCP":
-		p |= syslog.LOG_UUCP
-	case "LOG_CRON":
-		p |= syslog.LOG_CRON
-	case "LOG_AUTHPRIV":
-		p |= syslog.LOG_AUTHPRIV
-	case "LOG_FTP":
-		p |= syslog.LOG_FTP
-	case "LOG_LOCAL0":
-		p |= syslog.LOG_LOCAL0
-	case "LOG_LOCAL1":
-		p |= syslog.LOG_LOCAL1
-	case "LOG_LOCAL2":
-		p |= syslog.LOG_LOCAL2
-	case "LOG_LOCAL3":
-		p |= syslog.LOG_LOCAL3
-	case "LOG_LOCAL4":
-		p |= syslog.LOG_LOCAL4
-	case "LOG_LOCAL5":
-		p |= syslog.LOG_LOCAL5
-	case "LOG_LOCAL6":
-		p |= syslog.LOG_LOCAL6
-	case "LOG_LOCAL7":
-		p |= syslog.LOG_LOCAL7
-	default:
-		p |= syslog.LOG_LOCAL7
+	f, ok := facilityMap[facility]
+	if !ok {
+		f = syslog.LOG_LOCAL7
 	}
-	return p
+
+	return p | f
 }
 
 func NewServer(syslogAddress string, syslogPriority syslog.Priority) (*Server, error) {
-	var err error
-	var writer *syslog.Writer
 	s := new(Server)
 	s.syslogAddress = syslogAddress
 	s.syslogPriority = syslogPriority
 
-	writer, err = syslog.Dial("udp", s.syslogAddress, s.syslogPriority,
-		"pixel")
-
+	writer, err := syslog.Dial("udp", s.syslogAddress, s.syslogPriority, "pixel")
 	if err != nil {
 		return nil, err
 	}
@@ -163,13 +133,14 @@ func isFlatJSON(i interface{}) bool {
 
 // Returns a new *Event. *http.Request can be either a pixel or a
 // JSON POST request.
-func NewEvent(t time.Time, r *http.Request) (event *Event, err error) {
-	event = &Event{
-		Time:      t.UTC().Format(ISO8601_FORMAT),
+func NewEvent(t time.Time, r *http.Request) (*Event, error) {
+	event := &Event{
+		Time:      t.UTC().Format(ISO8601Format),
 		UserAgent: r.Header.Get("User-Agent"),
 		IP:        r.Header.Get("X-Forwarded-For"),
 		Proto:     r.Header.Get("X-Forwarded-Proto"),
 	}
+	var err error
 
 	switch r.Method {
 	case "GET":
@@ -189,14 +160,13 @@ func NewEvent(t time.Time, r *http.Request) (event *Event, err error) {
 		var body []byte
 		var n int
 		if r.ContentLength > 0 {
-			if r.ContentLength > POST_BODY_MAX_LEN {
-				err = fmt.Errorf("POST body exceeds max length: %d",
-					r.ContentLength)
+			if r.ContentLength > PostBodyMaxLen {
+				err = fmt.Errorf("POST body exceeds max length: %d", r.ContentLength)
 				break
 			}
 			body = make([]byte, r.ContentLength)
 		} else if r.ContentLength == -1 {
-			body = make([]byte, POST_BODY_MAX_LEN)
+			body = make([]byte, PostBodyMaxLen)
 		} else {
 			err = fmt.Errorf("Empty POST body")
 			break
@@ -221,14 +191,14 @@ func NewEvent(t time.Time, r *http.Request) (event *Event, err error) {
 	if err != nil {
 		event.Error = err.Error()
 	}
-	return
+	return event, err
 }
 
-func (s *Server) parseRequest(w http.ResponseWriter, r *http.Request) (event *Event, err error) {
-	event, err = NewEvent(s.now(), r)
+func (s *Server) parseRequest(w http.ResponseWriter, r *http.Request) (*Event, error) {
+	event, err := NewEvent(s.now(), r)
 	if err != nil {
 		log.Printf("%s", err)
-		http.Error(w, BAD_REQUEST, http.StatusBadRequest)
+		http.Error(w, BadRequest, http.StatusBadRequest)
 	}
 	return event, err
 }
@@ -249,7 +219,7 @@ func (s *Server) trackPixel(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.Header().Set("Content-Type", "image/gif")
-	w.Write(TRANSPARENT_1_PX_GIF_BYTES)
+	w.Write([]byte(Transparent1PxGIF))
 }
 
 func (s *Server) trackJSON(w http.ResponseWriter, r *http.Request) {
@@ -272,7 +242,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		s.trackJSON(w, r)
 
 	default:
-		http.Error(w, BAD_REQUEST, http.StatusBadRequest)
+		http.Error(w, BadRequest, http.StatusBadRequest)
 	}
 }
 

--- a/server_test.go
+++ b/server_test.go
@@ -272,10 +272,14 @@ var udpTests = []struct {
 	},
 	// Invalid requests
 	{
-		"GET", "/", "%gh&%ij", "",
+		"GET", "/", "%gh&%ij",
+		`{"t":"` + STATIC_ISO8601 + `",` +
+			`"error":"Malformed query string: invalid URL escape \"%gh\""}`,
 	},
 	{
-		"POST", "/", "a=1&b=2", "",
+		"POST", "/", "a=1&b=2",
+		`{"t":"` + STATIC_ISO8601 + `",` +
+			`"error":"invalid character 'a' looking for beginning of value"}`,
 	},
 }
 

--- a/server_test.go
+++ b/server_test.go
@@ -2,12 +2,15 @@ package pixel
 
 import (
 	"encoding/json"
+	"io/ioutil"
 	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"reflect"
 	"regexp"
+	"strconv"
+	"strings"
 	"testing"
 	"time"
 )
@@ -22,28 +25,34 @@ func init() {
 	STATIC_TIME = time.Date(2015, 3, 22, 4, 31, 44, 0, time.UTC)
 }
 
-func assertEqual(t *testing.T, expected, actual interface{}) {
+func assertEqual(t *testing.T, prefix string, expected, actual interface{}) {
 	if !reflect.DeepEqual(actual, expected) {
 		var expectedJSON, actualJSON []byte
 
 		expectedJSON, _ = json.MarshalIndent(expected, "", "    ")
 		actualJSON, _ = json.MarshalIndent(actual, "", "    ")
 
-		t.Errorf("Expected != actual\n\n%s\n\n%s", expectedJSON,
-			actualJSON)
+		t.Errorf("%s - expected != actual:\n\n%s\n!=\n%s",
+			prefix, expectedJSON, actualJSON)
 	}
 }
 
-func emptyEvent(t *testing.T) (timestamp time.Time, r *http.Request, e *Event) {
+func emptyEvent(t *testing.T, body string) (timestamp time.Time, r *http.Request, e *Event) {
 	var err error
-	r, err = http.NewRequest("GET", "http://localhost/393", nil)
+	if body == "" {
+		r, err = http.NewRequest("GET", "http://localhost/393", nil)
+	} else {
+		r, err = http.NewRequest("POST", "http://localhost/393",
+			ioutil.NopCloser(strings.NewReader(body)))
+		r.ContentLength = int64(len(body))
+	}
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	e = &Event{
 		Time:   STATIC_ISO8601,
-		Params: map[string]string{},
+		Params: make(map[string]string),
 	}
 	return STATIC_TIME, r, e
 }
@@ -66,63 +75,103 @@ func newTestServer(t *testing.T, syslogAddress string) *Server {
 
 var eventTests = []struct {
 	headers map[string]string
-	params  map[string]string
 	IP      string
 	proto   string
+	params  map[string]string
+	body    string
 }{
+	// GET requests
 	{
 		map[string]string{},
+		"",
+		"",
 		map[string]string{},
-		"", "",
+		"",
 	},
 	{
 		map[string]string{
 			"X-Forwarded-For":   "169.254.169.254",
 			"X-Forwarded-Proto": "https",
 		},
-		map[string]string{},
 		"169.254.169.254",
 		"https",
+		map[string]string{},
+		"",
 	},
 	{
 		map[string]string{
 			"X-Forwarded-For":   "169.254.169.254",
 			"X-Forwarded-Proto": "https",
 		},
+		"169.254.169.254",
+		"https",
 		map[string]string{"k": "some_k", "foo": "gar"},
-		"169.254.169.254",
-		"https",
+		"",
+	},
+	// POST requests
+	{
+		map[string]string{},
+		"",
+		"",
+		nil,
+		`{"k": "some_k", "foo": "gar"}`,
 	},
 }
 
 func TestNewEvent(t *testing.T) {
 	var k, v string
 	var err error
-	for _, eventTest := range eventTests {
-		timestamp, r, expected := emptyEvent(t)
+	var r *http.Request
+	var timestamp time.Time
+	var expected *Event
+
+	check := func(prefix string) {
+		actual, err := NewEvent(timestamp, r)
+		if err != nil {
+			t.Fatalf("%s - %s", prefix, err)
+		}
+		assertEqual(t, prefix, expected, actual)
+	}
+
+	for index, eventTest := range eventTests {
+		timestamp, r, expected = emptyEvent(t, eventTest.body)
 		for k, v = range eventTest.headers {
 			r.Header.Set(k, v)
 		}
 		expected.IP = eventTest.IP
 		expected.Proto = eventTest.proto
 
-		params := url.Values{}
-		for k, v = range eventTest.params {
-			params.Set(k, v)
-			expected.Params[k] = v
-		}
-		r.URL, err = url.Parse("http://localhost/")
-		if err != nil {
-			t.Fatal(err)
-		}
-		r.URL.RawQuery = params.Encode()
+		if eventTest.body == "" {
+			eventParams := make(map[string]string)
+			urlParams := url.Values{}
+			for k, v = range eventTest.params {
+				urlParams.Set(k, v)
+				eventParams[k] = v
+			}
+			expected.Params = eventParams
 
-		actual, err := NewEvent(timestamp, r)
-		if err != nil {
-			t.Fatal(err)
+			r.URL, err = url.Parse("http://localhost/")
+			if err != nil {
+				t.Fatal(index, err)
+			}
+			r.URL.RawQuery = urlParams.Encode()
+			check(string(index))
+		} else {
+			var p interface{}
+			expected.Params = &p
+			err = json.Unmarshal([]byte(eventTest.body),
+				expected.Params)
+			if err != nil {
+				t.Fatal(index, err)
+			}
+			check(strconv.Itoa(index))
+
+			// Re-test the request with no content-length set.
+			r.Body = ioutil.NopCloser(strings.NewReader(eventTest.body))
+			r.ContentLength = -1
+			check(strconv.Itoa(index))
 		}
 
-		assertEqual(t, expected, actual)
 	}
 }
 
@@ -133,26 +182,43 @@ func TestNewEvent(t *testing.T) {
 var badRequest = http.StatusText(http.StatusBadRequest) + "\n"
 
 var httpTests = []struct {
-	method   string
-	path     string
-	rawQuery string
-	code     int
-	body     string
+	method       string
+	path         string
+	rawParams    string
+	code         int
+	responseBody string
 }{
+	// Valid requests
 	{"GET", "/", "", 200, TRANSPARENT_1_PX_GIF},
 	{"GET", "/", "a=1&b=2", 200, TRANSPARENT_1_PX_GIF},
+	{"POST", "/", `{}`, 200, "{}"},
+	{"POST", "/", `{"a": 1, "b": "2"}`, 200, "{}"},
+
+	// Invalid requests
 	{"GET", "/", "%gh&%ij", 400, badRequest},
 	{"POST", "/", "", 400, badRequest},
+	{"POST", "/", `{"a": 1 "b": "2"}`, 400, badRequest},
+	{"POST", "/",
+		`{"a": 1, "b": "paddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpaddingpadd"}`,
+		400, badRequest},
+	{"POST", "/", `{"a": 1, "b": {"a": 1}`, 400, badRequest},
 }
 
 func serveRequest(t *testing.T, server *Server, method, path,
-	rawQuery string) *httptest.ResponseRecorder {
+	rawParams string) *httptest.ResponseRecorder {
 	w := httptest.NewRecorder()
-	_, r, _ := emptyEvent(t)
-	r.Method = method
+	var r *http.Request
+	switch method {
+	case "GET":
+		_, r, _ = emptyEvent(t, "")
+		r.URL.RawQuery = rawParams
+	case "POST":
+		_, r, _ = emptyEvent(t, rawParams)
+		r.Method = "POST"
+	default:
+		t.Fatal("Not implemented!")
+	}
 	r.URL.Path = path
-	r.URL.RawQuery = rawQuery
-
 	server.ServeHTTP(w, r)
 	return w
 }
@@ -161,9 +227,9 @@ func TestServeHTTP(t *testing.T) {
 	server := newTestServer(t, "")
 	for _, httpTest := range httpTests {
 		w := serveRequest(t, server, httpTest.method, httpTest.path,
-			httpTest.rawQuery)
+			httpTest.rawParams)
 
-		expected := httpTest.body
+		expected := httpTest.responseBody
 		actual := w.Body.String()
 		if expected != actual {
 			t.Errorf("Expected body %q != actual %q", expected, actual)
@@ -190,15 +256,21 @@ func extractMessage(packet string) string {
 }
 
 var udpTests = []struct {
-	method   string
-	path     string
-	rawQuery string
-	packet   string
+	method    string
+	path      string
+	rawParams string
+	packet    string
 }{
+	// Valid requests
 	{
 		"GET", "/", "a=1&b=2",
 		`{"t":"` + STATIC_ISO8601 + `","params":{"a":"1","b":"2"}}`,
 	},
+	{
+		"POST", "/", `{"a": 1, "b": "2"}`,
+		`{"t":"` + STATIC_ISO8601 + `","params":{"a":1,"b":"2"}}`,
+	},
+	// Invalid requests
 	{
 		"GET", "/", "%gh&%ij", "",
 	},
@@ -231,7 +303,7 @@ func TestSendUdp(t *testing.T) {
 
 	for _, udpTest := range udpTests {
 		serveRequest(t, server, udpTest.method, udpTest.path,
-			udpTest.rawQuery)
+			udpTest.rawParams)
 		udpconn.SetReadDeadline(time.Now().Add(50 * time.Millisecond))
 
 		numBytes, _, err = udpconn.ReadFromUDP(messageBuf)

--- a/server_test.go
+++ b/server_test.go
@@ -181,8 +181,8 @@ var httpTests = []struct {
 	responseBody string
 }{
 	// Valid requests
-	{"GET", "/", "", 200, Transparent1PxGIF},
-	{"GET", "/", "a=1&b=2", 200, Transparent1PxGIF},
+	{"GET", "/", "", 200, string(Transparent1PxGIF)},
+	{"GET", "/", "a=1&b=2", 200, string(Transparent1PxGIF)},
 	{"POST", "/", `{}`, 200, "{}"},
 	{"POST", "/", `{"a": 1, "b": "2"}`, 200, "{}"},
 


### PR DESCRIPTION
- General Event.Params -> interface{} so it can be used for both
  pixel and JSON POST events.
- Extend server to handle POST requests with valid post bodies
  (and to fail for invalid POST bodies).
- Log even invalid requests by including an additional "error" field
- Omit the "params" field when it is empty.
- Don't assign the params field until after JSON encoding succeeds.
- Add sections on development and sample requests to README.md
